### PR TITLE
Add paste support for Unity 2021.2

### DIFF
--- a/Assets/WebGLCopyAndPaste/Plugins/WebGLCopyAndPaste.jslib
+++ b/Assets/WebGLCopyAndPaste/Plugins/WebGLCopyAndPaste.jslib
@@ -69,7 +69,12 @@ var WebGLCopyAndPaste = {
         var bufferSize = lengthBytesUTF8(str) + 1;
         var buffer = _malloc(bufferSize);
         stringToUTF8(str, buffer, bufferSize);
-        Runtime.dynCall('vi', callback, [buffer]);
+        try {
+          Runtime.dynCall('vi', callback, [buffer]);
+        } catch(e) {
+          // block is triggered on >=2021.2
+          Module['dynCall_vi'](callback, buffer);
+        }
       }
 
       WebGLCopyAndPaste.data =


### PR DESCRIPTION
In Unity 2021.2 the Runtime variable has been removed. This leads to a hard crash when trying to paste into the WebGL build when using Unity 2021.2. I encapsulated the breaking call in a try-catch-block and run a working call in the catch block. This should make it work for all versions again. Details regarding this issue can be found in this [StackOverflow post](https://stackoverflow.com/questions/70411564/unity-webgl-throws-error-referenceerror-runtime-is-not-defined).